### PR TITLE
Add skeleton React + FastAPI project

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-# nuddler-gtp-workspace
+# Project Skeleton
+
+This repository contains a simple project skeleton consisting of:
+
+* **Backend**: Python with [FastAPI](https://fastapi.tiangolo.com/) and Celery for background tasks. Example database configuration uses PostgreSQL via SQLAlchemy.
+* **Frontend**: A minimal React setup using Webpack and Babel.
+* **Queue**: Celery configured with Redis as the broker and backend.
+
+## Structure
+
+```
+backend/        # Python backend
+frontend/       # React frontend
+```
+
+## Running Backend
+
+Create a virtual environment and install requirements:
+
+```
+python -m venv venv
+source venv/bin/activate
+pip install -r backend/requirements.txt
+```
+
+Start the API server:
+
+```
+uvicorn backend.app.main:app --reload
+```
+
+Run the Celery worker in a separate terminal:
+
+```
+python -m backend.app.celery_worker
+```
+
+## Running Frontend
+
+Install Node dependencies and start the development server:
+
+```
+cd frontend
+npm install
+npm run start
+```
+
+This will serve the React app on [http://localhost:3000](http://localhost:3000).

--- a/backend/app/celery_worker.py
+++ b/backend/app/celery_worker.py
@@ -1,0 +1,4 @@
+from .tasks import celery_app
+
+if __name__ == '__main__':
+    celery_app.worker_main()

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,9 @@
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker
+
+DATABASE_URL = os.getenv('DATABASE_URL', 'postgresql://user:password@localhost:5432/appdb')
+engine = create_engine(DATABASE_URL)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,17 @@
+from fastapi import FastAPI
+from .database import engine, Base
+from .tasks import example_task
+
+app = FastAPI()
+
+# Create database tables
+Base.metadata.create_all(bind=engine)
+
+@app.get("/")
+def read_root():
+    return {"message": "Hello, world!"}
+
+@app.post("/task")
+def run_task():
+    example_task.delay()
+    return {"status": "task queued"}

--- a/backend/app/tasks.py
+++ b/backend/app/tasks.py
@@ -1,0 +1,12 @@
+import os
+from celery import Celery
+
+celery_app = Celery(
+    'worker',
+    broker=os.getenv('CELERY_BROKER_URL', 'redis://localhost:6379/0'),
+    backend=os.getenv('CELERY_RESULT_BACKEND', 'redis://localhost:6379/0')
+)
+
+@celery_app.task
+def example_task():
+    print("Task executed")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+SQLAlchemy
+psycopg2-binary
+celery
+redis

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "webpack serve --mode development",
+    "build": "webpack --mode production"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "webpack": "^5.0.0",
+    "webpack-cli": "^5.0.0",
+    "webpack-dev-server": "^4.0.0",
+    "@babel/core": "^7.0.0",
+    "@babel/preset-react": "^7.0.0",
+    "babel-loader": "^9.0.0"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>React App</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="/bundle.js"></script>
+  </body>
+</html>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+export default function App() {
+  return (
+    <div>
+      <h1>Hello from React</h1>
+    </div>
+  );
+}

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,0 +1,27 @@
+const path = require('path');
+
+module.exports = {
+  entry: './src/index.js',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.js'
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-react']
+          }
+        }
+      }
+    ]
+  },
+  devServer: {
+    static: path.join(__dirname, 'public'),
+    port: 3000
+  }
+};


### PR DESCRIPTION
## Summary
- set up FastAPI backend with SQLAlchemy and Celery
- add a minimal React frontend with Webpack and Babel
- document usage in README

## Testing
- `python -m py_compile backend/app/*.py`
- `node -e "console.log('ok')"`

------
https://chatgpt.com/codex/tasks/task_e_684e8afc60e0833297112718d14273b4