### PR TITLE
Add script to run entire app

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ backend/        # Python backend
 frontend/       # React frontend
 ```
 
-## Running Backend
+## Running Backend Manually
 
 Create a virtual environment and install requirements:
 
@@ -35,7 +35,7 @@ Run the Celery worker in a separate terminal:
 python -m backend.app.celery_worker
 ```
 
-## Running Frontend
+## Running Frontend Manually
 
 Install Node dependencies and start the development server:
 
@@ -46,3 +46,14 @@ npm run start
 ```
 
 This will serve the React app on [http://localhost:3000](http://localhost:3000).
+
+## Using the helper script
+
+A convenience script `start_app.sh` is provided to start the API, Celery worker and React app in one step. Execute it from the project root:
+
+```
+./start_app.sh
+```
+
+The script creates a virtual environment if needed, installs dependencies and runs all services concurrently. Press `Ctrl-C` to stop them.
+

--- a/start_app.sh
+++ b/start_app.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Simple script to run backend API, Celery worker and React frontend
+
+set -e
+
+# Prepare Python virtual environment
+if [ ! -d "venv" ]; then
+    python -m venv venv
+fi
+source venv/bin/activate
+pip install -r backend/requirements.txt
+
+# Start backend API
+uvicorn backend.app.main:app --reload &
+API_PID=$!
+
+# Start Celery worker
+python -m backend.app.celery_worker &
+CELERY_PID=$!
+
+# Start frontend
+cd frontend
+npm install
+npm run start &
+FRONTEND_PID=$!
+
+trap "kill $API_PID $CELERY_PID $FRONTEND_PID" EXIT
+wait $API_PID $CELERY_PID $FRONTEND_PID


### PR DESCRIPTION
## Summary
- add `start_app.sh` to run backend, Celery worker and frontend together
- document usage of the helper script in README

## Testing
- `bash -n start_app.sh`

------
https://chatgpt.com/codex/tasks/task_e_684e8ccd09588332859cf9791716d10d